### PR TITLE
Fix #1: use findBy and samaccountname field for search user in AD.

### DIFF
--- a/Adapter/LDAP/Client.php
+++ b/Adapter/LDAP/Client.php
@@ -102,7 +102,7 @@ class Client implements ClientInterface
         }
         if ($this->logger)
             $this->logger->info("Authentication succeeded for user: '$username'");
-        $user = $provider->search()->find($username);
+        $user = $provider->search()->findBy('samaccountname', $username);
         if (! $user) {
             if ($this->logger)
                 $this->logger->info("User not found");


### PR DESCRIPTION
Searching users using ANR field can potentially find records that can be not user objects. Using samaccountname field gives more accurate results for our use cases.